### PR TITLE
rename carla autopilot class

### DIFF
--- a/CARLOS_CHANGELOG.md
+++ b/CARLOS_CHANGELOG.md
@@ -9,3 +9,5 @@
 *   Update to Ubuntu 22.04 and Python 3.10 including corresponding pip versions
 
 ### Minor changes
+
+*   Small fix related to CARLA autopilot

--- a/srunner/scenariomanager/actorcontrols/carla_autopilot.py
+++ b/srunner/scenariomanager/actorcontrols/carla_autopilot.py
@@ -18,7 +18,7 @@ Limitations:
 from srunner.scenariomanager.actorcontrols.basic_control import BasicControl
 
 
-class CarlaAutoPilotControl(BasicControl):
+class CarlaAutopilot(BasicControl):
 
     """
     Controller class for vehicles derived from BasicControl.
@@ -33,7 +33,7 @@ class CarlaAutoPilotControl(BasicControl):
     """
 
     def __init__(self, actor, args=None):
-        super(CarlaAutoPilotControl, self).__init__(actor)
+        super(CarlaAutopilot, self).__init__(actor)
         self._actor.set_autopilot(enabled=True)
 
     def reset(self):


### PR DESCRIPTION
This fixes the issue where scenarios can't use the CARLA autopilot due to some parsing logic that expects control classes to follow this naming schema:
File / Classname
actor_control.py -> ActorControl (Works)
carla_autopilot.py -> CarlaAutoPilotControl (Doesn't work)
carla_autopilot.py -> CarlaAutopilot (Would work)
carla_auto_pilot_control.py -> CarlaAutoPilotControl (Would also work)
