### PR TITLE
Feature/exit status

### DIFF
--- a/CARLOS_CHANGELOG.md
+++ b/CARLOS_CHANGELOG.md
@@ -11,3 +11,4 @@
 ### Minor changes
 
 *   Small fix related to CARLA autopilot
+*   Modified `scenario_runner.py` to return the result of scenario execution as exit code

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -270,10 +270,12 @@ class ScenarioRunner(object):
 
         if not self.manager.analyze_scenario(self._args.output, filename, junit_filename, json_filename):
             print("All scenario tests were passed successfully!")
+            return True
         else:
             print("Not all scenario tests were successful")
             if not (self._args.output or filename or junit_filename):
                 print("Please run with --output for further information")
+            return False
 
     def _record_criteria(self, criteria, name):
         """
@@ -427,15 +429,13 @@ class ScenarioRunner(object):
             self.manager.run_scenario()
 
             # Provide outputs if required
-            self._analyze_scenario(config)
+            result = self._analyze_scenario(config)
 
             # Remove all actors, stop the recorder and save all criterias (if needed)
             scenario.remove_all_actors()
             if self._args.record:
                 self.client.stop_recorder()
                 self._record_criteria(self.manager.scenario.get_criteria(), recorder_name)
-
-            result = True
 
         except Exception as e:              # pylint: disable=broad-except
             traceback.print_exc()


### PR DESCRIPTION
`scenario_runner.py` printed the final evaluation of the executed scenario, but always returned `True` if the scenario could be fully executed, completely disregarding the evaluation.

With these changes the `_analyze_scenario` function now also returns `True` if all required criteria are met and `False` if not.
